### PR TITLE
Create flash-messages.component.js

### DIFF
--- a/flash-messages.component.js
+++ b/flash-messages.component.js
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { FlashMessagesService, } from './flash-messages.service';
+var FlashMessagesComponent = (function () {
+    function FlashMessagesComponent(flashMessagesService) {
+        this.flashMessagesService = flashMessagesService;
+        this.messages = [];
+    }
+    FlashMessagesComponent.prototype.ngOnInit = function () {
+        var _this = this;
+        this.flashMessagesService.message.subscribe(function (message) {
+            _this.handleMessage(message);
+        });
+    };
+    FlashMessagesComponent.prototype.handleMessage = function (message) {
+        var _this = this;
+        var defaultOpts = {
+            classes: [],
+            timeout: 3000
+        };
+        Object.assign(defaultOpts, message.options);
+        message.options = defaultOpts;
+        var timestamp = message.timestamp = +new Date();
+        this.messages.push(message);
+        setTimeout(function () {
+            _this.messages = _this.messages.filter(function (msg) { return msg.timestamp !== timestamp; });
+        }, message.options.timeout);
+    };
+    return FlashMessagesComponent;
+}());
+export { FlashMessagesComponent };
+FlashMessagesComponent.decorators = [
+    { type: Component, args: [{
+                selector: 'ngx-flash-messages',
+                template: "<div id=\"flashMessages\" class=\"flash-messages\"><div class=\"flash-message\" *ngFor=\"let message of messages\" [ngClass]=\"message.options.classes\"><p>{{ message.text }}</p></div></div>",
+            },] },
+];
+/** @nocollapse */
+FlashMessagesComponent.ctorParameters = function () { return [
+    { type: FlashMessagesService, },
+]; };
+//# sourceMappingURL=flash-messages.component.js.map


### PR DESCRIPTION
I'm new at this but I was trying to help remove a bug well in regards to this working with Foundation 6. I couldn't find this file in the github, but it resides in the lib-dist folder when using Angular 2. Anyways, the "alert" in the class was triggering the foundation alert css and even when you added class "success" to the flash message it was being overridden by that default class. When removing "alert" from the default class it worked as expected. Again sorry I'm new at this.
line 34 I removed "alert" from the div class for the template.